### PR TITLE
Callback to process successful server response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ grunt.initConfig({
         },
         data: {
           someKey: 'some value'
+        },
+        onComplete: function(data) {
+            console.log('Response: ' + data);
         }
       },
       src: '<%= yeoman.dist %>/dist.zip',
@@ -86,6 +89,12 @@ Type: `Object`
 DefaultValue: `{}`
 
 Headers to send along with your HTTP request. For example, a lot of API require the Authentication to be sent through the Headers.
+
+#### options.onComplete
+Type: `Function`
+DefaultValue: `function(data) {}`
+
+Callback used to process server's response. For example, when server returns id of uploaded file you need to process afterwards.
 
 #### src
 Type: `String`

--- a/tasks/http_upload.js
+++ b/tasks/http_upload.js
@@ -23,7 +23,8 @@ module.exports = function(grunt) {
       rejectUnauthorized: true,
       method: 'POST',
       headers: {},
-      url:    ''
+      url:    '',
+      onComplete: function(data) {}
     });
 
     grunt.verbose.writeflags(options, 'Options');
@@ -61,6 +62,7 @@ module.exports = function(grunt) {
           }).on('complete', function(data, response) {
             if (response !== null && response.statusCode >= 200 && response.statusCode < 300) {
               grunt.log.ok('Upload successful of "' + filepath + '" as "' + field + '" - ' + options.method + ' @ ' + options.url);
+              options.onComplete(data);
             } else if (response !== null) {
                 grunt.fail.warn('Failed uploading "' + filepath + '" as "' + field + '" (status code: ' + response.statusCode + ') - ' + options.method + ' @ ' + options.url);
             } else {


### PR DESCRIPTION
I've added a callback option to allow processing successful server responses.

It solves following issue: https://github.com/DiscoverGrunt/grunt-http-upload/issues/6
